### PR TITLE
Add cap and progress bars to Light and fix up the visual look.

### DIFF
--- a/css/master.css
+++ b/css/master.css
@@ -1,0 +1,124 @@
+h1, h2, h3, h4, h5, h6 {
+  text-align: center;
+}
+
+div.header {
+  text-align: center;
+}
+div.header h2 {
+  margin-bottom: 7px;
+}
+div.header h5 {
+  margin-top: 5px;
+}
+
+#upgrade_list {
+  padding: 0;
+}
+#upgrade_list > * {
+  display: none;
+  text-align: center;
+}
+
+#upgrade_annihilation_multiplier {
+  display: none;
+  text-align: center;
+}
+
+/* Resources Display */
+div.resources {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+}
+div.resources .resources-item {
+  min-width: 33%;
+  max-width: 100%;
+  text-align: center;
+  display: none;
+}
+div.resources .resources-item h3 {
+  margin-bottom: 5px;
+}
+div.resources .resources-item h5 {
+  margin-top: 5px;
+}
+
+/* Save */
+div.data > div {
+  display: flex;
+}
+div.data > div div {
+  min-width: 50%;
+  max-width: 100%;
+  text-align: center;
+}
+div.data > div div ul {
+  list-style-type: none;
+  padding: 0;
+}
+
+/* Statistics */
+div.statistics > div {
+  text-align: center;
+}
+
+#gen_breakdown {
+  margin: auto;
+}
+#gen_breakdown tbody > tr > td:nth-child(1) {
+  text-align: right;
+}
+#gen_breakdown tbody > tr > td:nth-child(2) {
+  text-align: left;
+}
+
+/* About */
+div.about > p {
+  margin-left: 30%;
+}
+
+body {
+  font-family: sans-serif;
+  background-color: #1a1b26;
+  color: #a9b1d6;
+  margin: 0;
+}
+
+hr {
+  color: #24283b;
+  border-top: 1px solid;
+}
+
+button {
+  padding: 5px 12px;
+  background-color: #24283b;
+  color: inherit;
+  border: 1px solid #414868;
+  border-radius: 7px;
+}
+button .ingredient-list {
+  padding-left: 5px;
+  margin-top: 5px;
+  margin-bottom: 0;
+}
+
+progress[value] {
+  appearance: none;
+  height: 10px;
+  background-color: #24283b;
+  accent-color: #FF0000;
+  border: 1px solid #414868;
+  border-radius: 8px;
+  /* Firefox */
+  /* Webkit and Blink */
+}
+progress[value]::-moz-progress-bar {
+  background-color: #7aa2f7;
+}
+progress[value]::-webkit-progress-bar {
+  background-color: #7aa2f7;
+}
+progress[value]::-webkit-progress-value {
+  background-color: #7aa2f7;
+}

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>Energy Enumerated!</title>
-		<link rel="stylesheet" href="master.css">
+		<link rel="stylesheet" href="scss/master.scss">
 		<link rel="icon" type="image/x-icon" href="favicon.ico">
 	</head>
 	<body>
@@ -15,9 +15,14 @@
 			<div id="shop">
 				<h4>Shop</h4>
 				<div class="shop-item" id="shop_enumerator">
-					<p>Energy Enumerator <sup>[<span id="enumerator_cost">20</span>]</sup></p>
-					<span class="count" id="enumerator_count">0</span>
-					<button onClick="buyEnumerator()">Buy!</button>
+					<p>Energy Enumerator <span class="number" id="enumerator_count">0</span></p>
+					<button onClick="buyEnumerator()">
+						Buy Energy Enumerator
+						<br>
+						<ul class="ingredient-list">
+							<li><span class="number" id="enumerator_cost">20</span> Energy</li>
+						</ul>
+					</button>
 				</div>
 			</div>
 			<hr>
@@ -27,7 +32,13 @@
 				<h3>Matter <span class="number" id="matter_number">0</span></h3>
 				<progress id="matter_progress" max=10 value=0></progress>
 				<h5>Cap: <span class="number" id="matter_cap">10</span></h5>
-				<button onClick="energyToMatter(100)">Condense Energy (100E -&gt; 1M)</button>
+				<button onClick="energyToMatter(100)">
+					Condense Energy
+					<br>
+					<ul class="ingredient-list">
+						<li><span class="number">100</span> Energy</li>
+					</ul>
+				</button>
 			</div>
 			<div class="resources-center resources-item annihilation" id="div_annihilation">
 				<h3>Matter-Antimatter annihilation</h3>
@@ -35,13 +46,27 @@
 				<h4>Speed: <span class="number" id="annihilation_speed">0</span>/s</h4>
 				<hr>
 				<h3>Light <span class="number" id="light_number">0</span></h3>
-				<button id="upgrade_annihilation_multiplier" onClick="upgradeAnnihilationMultiplier()">Double multiplier<sup>[<span class="number" id="annihilation_multiplier_cost">1</span> L]</sup></button>
+				<progress id="light_progress" max=1 value=0></progress>
+				<h5>Cap: <span class="number" id="light_cap">1</span></h5>
+				<button id="upgrade_annihilation_multiplier" onClick="upgradeAnnihilationMultiplier()">
+					Double multiplier
+					<br>
+					<ul class="ingredient-list">
+						<li><span class="number" id="annihilation_multiplier_cost">1</span> Light</li>
+					</ul>
+				</button>
 			</div>
 			<div class="resources-right resources-item antimatter" id="div_antimatter">
 				<h3>Antimatter <span class="number" id="antimatter_number">0</span></h3>
 				<progress id="antimatter_progress" max=1 value=0></progress>
 				<h5>Cap: <span class="number" id="antimatter_cap">1</span></h5>
-				<button id="condense_antimatter_button" onClick="energyToAntimatter(100)">Condense Energy (100E -&gt; 1AM)</button>
+				<button id="condense_antimatter_button" onClick="energyToAntimatter(100)">
+					Condense Energy
+					<br>
+					<ul class="ingredient-list">
+						<li><span class="number">100</span> Energy</li>
+					</ul>
+				</button>
 			</div>
 		</div>
 		<hr>

--- a/scss/_layout.scss
+++ b/scss/_layout.scss
@@ -1,0 +1,91 @@
+h1, h2, h3, h4, h5, h6 {
+	text-align: center;
+}
+
+div.header {
+	text-align: center;
+
+	h2 {
+		margin-bottom: 7px;
+	}
+
+	h5 {
+		margin-top: 5px;
+	}
+}
+
+#upgrade_list {
+	padding: 0;
+
+	&>* {
+		display: none;
+		text-align: center;
+	}
+}
+
+#upgrade_annihilation_multiplier {
+	display: none;
+	text-align: center;
+}
+
+/* Resources Display */
+div.resources {
+	display: flex;
+	justify-content: space-between;
+	width: 100%;
+
+	.resources-item {
+		min-width: 33%;
+		max-width: 100%;
+		text-align: center;
+		display: none;
+
+		h3 {
+			margin-bottom: 5px;
+		}
+
+		h5 {
+			margin-top: 5px;
+		}
+	}
+}
+
+/* Save */
+div.data>div {
+	display: flex;
+
+	div {
+		min-width: 50%;
+		max-width: 100%;
+		text-align: center;
+
+		ul {
+			list-style-type: none;
+			padding: 0;
+		}
+	}
+}
+
+/* Statistics */
+div.statistics>div {
+	text-align: center;
+}
+
+#gen_breakdown {
+	margin: auto;
+
+	tbody>tr>td {
+		&:nth-child(1) {
+			text-align: right;
+		}
+		
+		&:nth-child(2) {
+			text-align: left;
+		}
+	}
+}
+
+/* About */
+div.about>p {
+	margin-left: 30%;
+}

--- a/scss/master.scss
+++ b/scss/master.scss
@@ -1,0 +1,50 @@
+@use 'layout';
+
+body {
+	font-family: sans-serif;
+	background-color: #1a1b26;
+	color: #a9b1d6;
+	margin: 0;
+}
+
+hr {
+	color: #24283b;
+	border-top: 1px solid;
+}
+
+button {
+	padding: 5px 12px;
+	background-color: #24283b;
+	color: inherit;
+	border: 1px solid #414868;
+	border-radius: 7px;
+
+	.ingredient-list {
+		padding-left: 5px;
+		margin-top: 5px;
+		margin-bottom: 0;
+	}
+}
+
+progress[value] {
+	appearance: none;
+	height: 10px;
+	background-color: #24283b;
+	//color: #7aa2f7;
+	accent-color: #FF0000;
+	border: 1px solid #414868;
+	border-radius: 8px;
+
+	/* Firefox */
+	&::-moz-progress-bar {
+		background-color: #7aa2f7;
+	}
+
+	/* Webkit and Blink */
+	&::-webkit-progress-bar {
+		background-color: #7aa2f7;
+	}
+	&::-webkit-progress-value {
+		background-color: #7aa2f7;
+	}
+}


### PR DESCRIPTION
this PR contains a couple of more general improvements to the game pulled out from my local typescript branch, I'm not sure whether we want these in the game before or after the `0.5` update (which will be adding in new content), this PR will be the last before new features are added to this branch.
I am aware `resources.js`, `save.js`, and `upgrades.js` still need to be rewritten for TS but those are stable enough that I don't feel like overhauling them just yet.

The main features of this PR are:
- new stylesheet, the game looks less ass than before, definitely needs a second pass but that will be for after 0.5 is out the door.
- Light now displays it's cap, the cap is not enforced yet (as to not change game behavior yet)
- Costs are now standardized into a cost list on the buttons, I'm not 100% sure I want this format going forwards, but at least it's not 3 standards mixed together.

if we were to merge this as-is before 0.5 then the only change that needs to be made is change link in the HTML to link to the compiled CSS and not the debug SCSS file (my development environment auto-compiles SCSS on request and I hadn't changed the link back before making this PR)